### PR TITLE
Portfolio Redesign v2: single-page resume

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,44 +1,7 @@
-<script>
-	const currentYear = new Date().getFullYear();
-</script>
-
 <footer class="border-t border-stone-200 dark:border-stone-800">
-	<div class="max-w-2xl mx-auto px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-4">
-		<p class="text-xs text-stone-400 dark:text-stone-600">
-			&copy; {currentYear} Philip Nordquist
-		</p>
-		<div class="flex items-center gap-5">
-			<a
-				href="https://github.com/c-j-p-nordquist"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-stone-400 hover:text-stone-600 dark:text-stone-600 dark:hover:text-stone-400 transition-all hover:scale-110 hover:-translate-y-0.5 active:scale-95 active:translate-y-0"
-				aria-label="GitHub"
-			>
-				<svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-					<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-				</svg>
-			</a>
-			<a
-				href="https://linkedin.com/in/philip-nordquist-269949a0"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-stone-400 hover:text-stone-600 dark:text-stone-600 dark:hover:text-stone-400 transition-all hover:scale-110 hover:-translate-y-0.5 active:scale-95 active:translate-y-0"
-				aria-label="LinkedIn"
-			>
-				<svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-					<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-				</svg>
-			</a>
-			<a
-				href="mailto:philip@nordquist.me"
-				class="text-stone-400 hover:text-stone-600 dark:text-stone-600 dark:hover:text-stone-400 transition-all hover:scale-110 hover:-translate-y-0.5 active:scale-95 active:translate-y-0"
-				aria-label="Email"
-			>
-				<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
-				</svg>
-			</a>
-		</div>
+	<div class="max-w-[640px] mx-auto px-6 py-[22px]">
+		<span class="text-xs text-stone-400 dark:text-stone-600">
+			&copy; 2026 Philip Nordquist
+		</span>
 	</div>
 </footer>

--- a/src/lib/components/JobEntry.svelte
+++ b/src/lib/components/JobEntry.svelte
@@ -1,0 +1,67 @@
+<script>
+	let { job, defaultOpen = false } = $props();
+	let open = $state(defaultOpen);
+	const has = job.highlights.length > 0;
+</script>
+
+<div
+	class="py-5"
+	class:cursor-pointer={has}
+	onclick={() => has && (open = !open)}
+	role={has ? 'button' : undefined}
+	tabindex={has ? 0 : undefined}
+	onkeydown={(e) => {
+		if (has && (e.key === 'Enter' || e.key === ' ')) {
+			e.preventDefault();
+			open = !open;
+		}
+	}}
+>
+	<div class="flex justify-between items-baseline gap-4 mb-[5px]">
+		<span
+			class="text-[14.5px] font-medium tracking-[-0.01em] leading-[1.3] text-stone-900 dark:text-stone-100"
+		>
+			{job.position}
+		</span>
+		<span
+			class="text-[11.5px] text-stone-400 dark:text-stone-600 shrink-0 tabular-nums"
+		>
+			{job.period}
+		</span>
+	</div>
+	<div class="text-[12.5px] text-stone-400 dark:text-stone-600 mb-[9px]">
+		{job.company} · {job.location}
+	</div>
+	<p
+		class="text-sm text-stone-600 dark:text-stone-400 leading-[1.68]"
+		style="text-wrap: pretty;"
+	>
+		{job.description}
+	</p>
+
+	{#if has && open}
+		<ul class="mt-3.5 list-none flex flex-col gap-[7px]">
+			{#each job.highlights as highlight}
+				<li
+					class="flex gap-2.5 text-[13px] text-stone-400 dark:text-stone-600 leading-[1.6]"
+				>
+					<span class="text-stone-200 dark:text-stone-800 shrink-0 text-[15px]">—</span>
+					<span style="text-wrap: pretty;">{highlight}</span>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	{#if has}
+		<div
+			class="mt-[11px] text-[11.5px] text-stone-400 dark:text-stone-600 flex items-center gap-[5px]"
+		>
+			<span
+				class="inline-flex items-center justify-center w-[14px] h-[14px] border border-stone-200 dark:border-stone-800 rounded-[3px] text-[12px] leading-none text-stone-400 dark:text-stone-600"
+			>
+				{open ? '−' : '+'}
+			</span>
+			{open ? 'Collapse' : 'Show highlights'}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -1,67 +1,51 @@
 <script>
-	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
 
-	let isMenuOpen = $state(false);
+	let scrolled = $state(false);
 
-	const navItems = [
-		{ href: '/', label: 'Home' },
-		{ href: '/about', label: 'About' },
-		{ href: '/posts', label: 'Writing' }
-	];
-
-	function isActive(href) {
-		if (href === '/') return $page.url.pathname === '/';
-		return $page.url.pathname.startsWith(href);
-	}
+	onMount(() => {
+		const onScroll = () => {
+			scrolled = window.scrollY > 8;
+		};
+		onScroll();
+		window.addEventListener('scroll', onScroll, { passive: true });
+		return () => window.removeEventListener('scroll', onScroll);
+	});
 </script>
 
-<nav class="sticky top-0 z-[100] bg-surface/80 dark:bg-surface-dark/80 backdrop-blur-md border-b border-stone-200 dark:border-stone-800 transition-colors duration-300">
-	<div class="max-w-2xl mx-auto px-6 h-14 flex items-center justify-between">
-		<a href="/" class="text-sm font-medium text-stone-900 dark:text-stone-100 tracking-tight">
+<nav
+	class="sticky top-0 z-[100] transition-[background-color,border-color] duration-200 ease-out"
+	class:scrolled
+>
+	<div class="max-w-[640px] mx-auto px-6 h-[54px] flex items-center">
+		<a
+			href="/"
+			class="text-sm font-medium tracking-[-0.02em] text-stone-900 dark:text-stone-100"
+		>
 			Philip Nordquist
 		</a>
-
-		<div class="hidden sm:flex items-center gap-6">
-			{#each navItems as item}
-				<a
-					href={item.href}
-					class="text-sm transition-colors {isActive(item.href)
-						? 'text-stone-900 dark:text-stone-100'
-						: 'text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300'}"
-				>
-					{item.label}
-				</a>
-			{/each}
-		</div>
-
-		<button
-			class="sm:hidden text-stone-600 dark:text-stone-400"
-			onclick={() => (isMenuOpen = !isMenuOpen)}
-			aria-label="Toggle menu"
-		>
-			<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-				{#if isMenuOpen}
-					<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-				{:else}
-					<path stroke-linecap="round" stroke-linejoin="round" d="M4 8h16M4 16h16" />
-				{/if}
-			</svg>
-		</button>
 	</div>
-
-	{#if isMenuOpen}
-		<div class="sm:hidden border-t border-stone-200 dark:border-stone-800 bg-surface/80 dark:bg-surface-dark/80 backdrop-blur-md px-6 py-3 space-y-1">
-			{#each navItems as item}
-				<a
-					href={item.href}
-					onclick={() => (isMenuOpen = false)}
-					class="block py-2 text-sm transition-colors {isActive(item.href)
-						? 'text-stone-900 dark:text-stone-100'
-						: 'text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300'}"
-				>
-					{item.label}
-				</a>
-			{/each}
-		</div>
-	{/if}
 </nav>
+
+<style>
+	nav {
+		background-color: transparent;
+		border-bottom: 1px solid transparent;
+	}
+	:global(.dark) nav,
+	nav {
+		/* default (top of page) */
+	}
+	nav.scrolled {
+		background-color: rgb(250 250 249 / 0.93);
+		backdrop-filter: blur(14px);
+		-webkit-backdrop-filter: blur(14px);
+		border-bottom-color: #e7e5e4;
+	}
+	@media (prefers-color-scheme: dark) {
+		nav.scrolled {
+			background-color: rgb(12 10 9 / 0.93);
+			border-bottom-color: #292524;
+		}
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,6 @@
 <script>
-	import { workHistory } from '$lib/data/workHistory.js';
-
-	const recentJobs = workHistory.slice(0, 3);
+	import { workHistory, education, certifications } from '$lib/data/workHistory.js';
+	import JobEntry from '$lib/components/JobEntry.svelte';
 </script>
 
 <svelte:head>
@@ -17,109 +16,176 @@
 	<meta name="twitter:title" content="Philip Nordquist" />
 </svelte:head>
 
-<div class="max-w-2xl mx-auto px-6 py-16 sm:py-24">
-	<section class="mb-16">
-		<h1 class="text-3xl sm:text-4xl font-semibold tracking-tight text-stone-900 dark:text-stone-100 mb-6">
+<div class="max-w-[640px] mx-auto px-6 pt-[72px] pb-[100px]">
+	<!-- Hero -->
+	<section class="mb-[88px]">
+		<h1
+			class="text-[30px] font-semibold tracking-[-0.03em] text-stone-900 dark:text-stone-100 mb-[18px] leading-[1.1]"
+		>
 			Philip Nordquist
 		</h1>
-		<p class="text-lg text-stone-600 dark:text-stone-400 leading-relaxed mb-4">
-			Platform and DevSecOps engineer in Linköping, Sweden. I work with
-			infrastructure, security, and keeping things running.
+
+		<p
+			class="text-[15.5px] text-stone-600 dark:text-stone-400 leading-[1.75] mb-2.5 max-w-[460px]"
+			style="text-wrap: pretty;"
+		>
+			Platform and DevSecOps engineer in Linköping, Sweden. I work with infrastructure,
+			security, and keeping things running.
 		</p>
-		<p class="text-lg text-stone-600 dark:text-stone-400 leading-relaxed mb-8">
-			Currently at <span class="text-stone-900 dark:text-stone-200">STIM</span>,
-			looking after their platform and security tooling.
-			Before that I was at <span class="text-stone-900 dark:text-stone-200">ExpressVPN</span>
+		<p
+			class="text-[15.5px] text-stone-600 dark:text-stone-400 leading-[1.75] mb-[30px] max-w-[460px]"
+			style="text-wrap: pretty;"
+		>
+			Currently at <strong class="text-stone-900 dark:text-stone-100 font-medium">STIM</strong>,
+			looking after their platform and security tooling. Before that at
+			<strong class="text-stone-900 dark:text-stone-100 font-medium">ExpressVPN</strong>
 			for a few years, working on infrastructure across 3,000+ servers in 100+ countries.
 		</p>
-		<div class="flex items-center gap-5">
+
+		<div class="flex items-center gap-[18px] flex-wrap">
 			<a
 				href="https://github.com/c-j-p-nordquist"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="group flex items-center gap-1 text-sm text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300 transition-colors"
+				class="group inline-flex items-center gap-1 text-[13px] text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors"
 			>
 				GitHub
-				<svg class="w-3 h-3 text-stone-400 dark:text-stone-600 group-hover:text-stone-900 dark:group-hover:text-stone-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25" /></svg>
+				<svg
+					class="w-[11px] h-[11px]"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M7 17L17 7M17 7H7M17 7v10" />
+				</svg>
 			</a>
 			<a
 				href="https://linkedin.com/in/philip-nordquist-269949a0"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="group flex items-center gap-1 text-sm text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300 transition-colors"
+				class="group inline-flex items-center gap-1 text-[13px] text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors"
 			>
 				LinkedIn
-				<svg class="w-3 h-3 text-stone-400 dark:text-stone-600 group-hover:text-stone-900 dark:group-hover:text-stone-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25" /></svg>
+				<svg
+					class="w-[11px] h-[11px]"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M7 17L17 7M17 7H7M17 7v10" />
+				</svg>
 			</a>
 			<a
 				href="mailto:philip@nordquist.me"
-				class="group flex items-center gap-1 text-sm text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300 transition-colors"
+				class="group inline-flex items-center gap-1 text-[13px] text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors"
 			>
 				Email
-				<svg class="w-3 h-3 text-stone-400 dark:text-stone-600 group-hover:text-stone-900 dark:group-hover:text-stone-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25" /></svg>
+				<svg
+					class="w-[11px] h-[11px]"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M7 17L17 7M17 7H7M17 7v10" />
+				</svg>
 			</a>
+			<div class="w-px h-[14px] bg-stone-200 dark:bg-stone-800"></div>
 			<a
 				href="/files/pn_resume_26.pdf"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="group flex items-center gap-1 text-sm text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300 transition-colors"
+				class="inline-flex items-center gap-[5px] text-[12.5px] font-medium px-[13px] py-[5px] rounded-[5px] border border-stone-200 dark:border-stone-800 text-stone-900 dark:text-stone-100 hover:bg-stone-900 hover:text-stone-50 hover:border-stone-900 dark:hover:bg-stone-100 dark:hover:text-stone-900 dark:hover:border-stone-100 transition-colors"
 			>
 				Resume
-				<svg class="w-3 h-3 text-stone-400 dark:text-stone-600 group-hover:text-stone-900 dark:group-hover:text-stone-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25" /></svg>
 			</a>
 		</div>
 	</section>
 
-	<hr class="border-stone-200 dark:border-stone-800 mb-16" />
+	<!-- Experience -->
+	<section class="mb-20">
+		<div class="flex items-center gap-[14px] mb-6">
+			<span
+				class="text-[10.5px] tracking-[0.1em] uppercase font-medium text-stone-400 dark:text-stone-600 whitespace-nowrap"
+			>
+				Experience
+			</span>
+			<div class="flex-1 h-px bg-stone-200 dark:bg-stone-800"></div>
+		</div>
 
-	<section class="mb-16">
-		<h2 class="text-xs font-medium uppercase tracking-widest text-stone-400 dark:text-stone-600 mb-8">
-			Experience
-		</h2>
-		<div class="space-y-1">
-			{#each recentJobs as job}
-				<div class="-mx-4 px-4 py-5 rounded-lg hover:bg-stone-50 dark:hover:bg-stone-900/40 transition-colors">
-					<div class="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 mb-2">
-						<h3 class="font-medium text-stone-900 dark:text-stone-100">
-							{job.position}
-						</h3>
-						<span class="text-sm text-stone-400 dark:text-stone-600 shrink-0">
-							{job.period}
+		{#each workHistory as job, i}
+			<JobEntry {job} />
+			{#if i < workHistory.length - 1}
+				<div class="h-px bg-stone-100 dark:bg-stone-900"></div>
+			{/if}
+		{/each}
+	</section>
+
+	<!-- Education & Certifications -->
+	<section class="mb-20">
+		<div class="flex items-center gap-[14px] mb-6">
+			<span
+				class="text-[10.5px] tracking-[0.1em] uppercase font-medium text-stone-400 dark:text-stone-600 whitespace-nowrap"
+			>
+				Education & Certifications
+			</span>
+			<div class="flex-1 h-px bg-stone-200 dark:bg-stone-800"></div>
+		</div>
+
+		{#each education as edu}
+			<div>
+				<div class="py-[18px]">
+					<div class="flex justify-between items-baseline gap-4 mb-[5px]">
+						<span
+							class="text-[14.5px] font-medium tracking-[-0.01em] text-stone-900 dark:text-stone-100"
+						>
+							{edu.institution}
+						</span>
+						<span class="text-[11.5px] text-stone-400 dark:text-stone-600 shrink-0">
+							{edu.period}
 						</span>
 					</div>
-					<p class="text-sm text-stone-500 dark:text-stone-500 mb-2">
-						{job.company} · {job.location}
-					</p>
-					<p class="text-stone-600 dark:text-stone-400 leading-relaxed">
-						{job.description}
-					</p>
+					<p class="text-[13px] text-stone-600 dark:text-stone-400">{edu.program}</p>
+				</div>
+				<div class="h-px bg-stone-100 dark:bg-stone-900"></div>
+			</div>
+		{/each}
+
+		<div class="py-[18px] flex flex-col gap-2">
+			{#each certifications as cert}
+				<div class="flex items-baseline gap-2.5">
+					<span class="text-[12px] text-stone-200 dark:text-stone-800 shrink-0">—</span>
+					<span class="text-sm text-stone-600 dark:text-stone-400">{cert}</span>
 				</div>
 			{/each}
 		</div>
-		<a
-			href="/about"
-			class="group inline-flex items-center gap-1 mt-6 text-sm text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300 transition-colors"
-		>
-			Full background
-			<svg class="w-3.5 h-3.5 text-stone-400 dark:text-stone-600 group-hover:text-stone-900 dark:group-hover:text-stone-300 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" /></svg>
-		</a>
 	</section>
 
-	<hr class="border-stone-200 dark:border-stone-800 mb-16" />
-
+	<!-- Day to day -->
 	<section>
-		<h2 class="text-xs font-medium uppercase tracking-widest text-stone-400 dark:text-stone-600 mb-8">
-			Writing
-		</h2>
-		<p class="text-stone-600 dark:text-stone-400 leading-relaxed mb-4">
-			I occasionally write about infrastructure, DevOps tooling, and things I've built or figured out along the way.
-		</p>
-		<a
-			href="/posts"
-			class="group inline-flex items-center gap-1 text-sm text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-300 transition-colors"
+		<div class="flex items-center gap-[14px] mb-6">
+			<span
+				class="text-[10.5px] tracking-[0.1em] uppercase font-medium text-stone-400 dark:text-stone-600 whitespace-nowrap"
+			>
+				Day to day
+			</span>
+			<div class="flex-1 h-px bg-stone-200 dark:bg-stone-800"></div>
+		</div>
+		<p
+			class="text-[14.5px] text-stone-600 dark:text-stone-400 leading-[1.75]"
+			style="text-wrap: pretty;"
 		>
-			Read posts
-			<svg class="w-3.5 h-3.5 text-stone-400 dark:text-stone-600 group-hover:text-stone-900 dark:group-hover:text-stone-300 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" /></svg>
-		</a>
+			Mostly Kubernetes, Terraform, and CI/CD pipelines. I spend a lot of time in AWS and
+			GCP. For observability I lean on Prometheus and Grafana. When something needs
+			automating I'll reach for Python, Go, or Bash depending on what fits.
+		</p>
 	</section>
 </div>


### PR DESCRIPTION
## Summary
- Implements the Portfolio Redesign v2 handoff from Claude Design as a single-page resume.
- Home page now lists all experience with click-to-expand highlights, combines education + certifications, and ends with a "Day to day" section.
- Nav reduced to the name only (transparent at top, blurred/bordered once scrolled > 8px); footer reduced to a copyright line.

## Notes for reviewers
- New component: `src/lib/components/JobEntry.svelte` (expandable job row, keyboard-accessible with Enter/Space).
- Uses exact spec tokens from the design (640px container, 54px nav, 30px h1, 15.5px body, 1.75 line-height). Tailwind's `stone` palette maps 1:1 to the design's hex values, so no config changes were needed.
- Font kept as the project's existing Geist — the prototype's Inter would be a site-wide swap outside the redesign's scope.
- `/about` and `/posts` routes are still on disk and reachable directly; the redesign simply doesn't link to them. Happy to delete them in a follow-up if that's the intent.
- Verified with `vite build` — no warnings.

## Test plan
- [ ] `npm run dev` and confirm home page matches the v2 mock (hero, experience with expand/collapse, edu+certs, day to day).
- [ ] Scroll the page and confirm the nav fades in background + border past the first few pixels.
- [ ] Toggle OS dark mode and confirm token mapping holds (bg, text, borders).
- [ ] Keyboard-test the highlight toggles (Tab to a job, Enter/Space to expand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)